### PR TITLE
fix: Build lifespan from on_startup/on_shutdown for Starlette 1.x (0.5.x backport)

### DIFF
--- a/ludic/web/app.py
+++ b/ludic/web/app.py
@@ -1,5 +1,7 @@
 import inspect
-from collections.abc import Callable, Mapping, Sequence
+import warnings
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from contextlib import asynccontextmanager
 from functools import wraps
 from typing import Any, Literal, TypeVar, cast
 
@@ -22,6 +24,27 @@ from .routing import Router
 
 TCallable = TypeVar("TCallable", bound=Callable[..., Any])
 TEndpoint = TypeVar("TEndpoint", bound=Endpoint[Attrs])
+
+
+def _build_lifespan(
+    on_startup: Sequence[Callable[[], Any]],
+    on_shutdown: Sequence[Callable[[], Any]],
+) -> Lifespan[Any]:
+    @asynccontextmanager
+    async def lifespan(app: Any) -> AsyncIterator[None]:
+        for handler in on_startup:
+            if is_async_callable(handler):
+                await handler()
+            else:
+                handler()
+        yield
+        for handler in on_shutdown:
+            if is_async_callable(handler):
+                await handler()
+            else:
+                handler()
+
+    return lifespan
 
 
 class LudicApp(Starlette):
@@ -59,9 +82,21 @@ class LudicApp(Starlette):
         for key, value in (exception_handlers or {}).items():
             self.add_exception_handler(key, value)
 
-        self.router = Router(
-            routes, on_startup=on_startup, on_shutdown=on_shutdown, lifespan=lifespan
-        )
+        if (on_startup or on_shutdown) and lifespan is not None:
+            raise AssertionError(
+                "Use either 'lifespan' or 'on_startup'/'on_shutdown', not both."
+            )
+
+        if on_startup or on_shutdown:
+            warnings.warn(
+                "The on_startup and on_shutdown parameters are deprecated, "
+                "use lifespan instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            lifespan = _build_lifespan(on_startup or (), on_shutdown or ())
+
+        self.router = Router(routes, lifespan=lifespan)
 
     def get(self, path: str, **kwargs: Any) -> Callable[[TCallable], TCallable]:
         """Register GET endpoint to the application."""

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -1,0 +1,61 @@
+import pytest
+from starlette.testclient import TestClient
+
+from ludic.html import div
+from ludic.web import LudicApp
+
+
+def test_lifespan_kwarg_is_supported() -> None:
+    state: dict[str, bool] = {"started": False, "stopped": False}
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def lifespan(app):  # type: ignore[no-untyped-def]
+        state["started"] = True
+        yield
+        state["stopped"] = True
+
+    app = LudicApp(lifespan=lifespan)
+
+    @app.get("/")
+    def index() -> div:
+        return div("ok")
+
+    with TestClient(app) as client:
+        assert state["started"] is True
+        assert client.get("/").status_code == 200
+    assert state["stopped"] is True
+
+
+def test_on_startup_and_on_shutdown_emit_deprecation_and_still_run() -> None:
+    calls: list[str] = []
+
+    def startup() -> None:
+        calls.append("startup")
+
+    async def shutdown() -> None:
+        calls.append("shutdown")
+
+    with pytest.warns(DeprecationWarning, match="on_startup"):
+        app = LudicApp(on_startup=[startup], on_shutdown=[shutdown])
+
+    @app.get("/")
+    def index() -> div:
+        return div("ok")
+
+    with TestClient(app) as client:
+        assert client.get("/").status_code == 200
+        assert calls == ["startup"]
+    assert calls == ["startup", "shutdown"]
+
+
+def test_lifespan_and_on_startup_cannot_be_combined() -> None:
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def lifespan(app):  # type: ignore[no-untyped-def]
+        yield
+
+    with pytest.raises(AssertionError):
+        LudicApp(on_startup=[lambda: None], lifespan=lifespan)


### PR DESCRIPTION
## Summary

- Backport of #140 to the 0.5.x stream.
- Starlette 1.0 removed the `on_startup` / `on_shutdown` kwargs from `Router.__init__` ([encode/starlette#3117](https://github.com/encode/starlette/pull/3117)), breaking `LudicApp` on Starlette >=1.0.
- Synthesize a `lifespan` from `on_startup`/`on_shutdown` if either is passed, emit a `DeprecationWarning`, and forbid combining the legacy kwargs with an explicit `lifespan`.

Fixes #137.

## Test plan

- [x] `pytest tests/web/test_app.py` — three new tests cover the lifespan path, the legacy deprecation path, and the conflict assertion.
- [x] Full suite on Python 3.12: `uv run --python 3.12 --with ".[full,test]" pytest` — 101 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)