### PR TITLE
Add ludic-components and ludic-web agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,30 @@ For more complex usage incorporating all capabilities of the framework:
 - inspect the [source of getludic.dev](https://github.com/getludic/web/blob/main/web/endpoints/docs/htmx.py) which is written with Ludic
 - check [this small repository](https://github.com/getludic/ludic-slides/blob/main/ludic_slides/components.py) rendering slides in the browser
 
+## Agent Skills
+
+Ludic ships two agent skills, installable via the [`skills`](https://www.npmjs.com/package/skills) CLI (works with any supported coding agent):
+
+- [`ludic-components`](skills/ludic-components/SKILL.md) — building components: t-string templating, `Component` / `ComponentStrict` typing, the catalog widgets, htmx attributes, the trusted-vs-untrusted (`Safe`) content boundary.
+- [`ludic-web`](skills/ludic-web/SKILL.md) — building web apps: `LudicApp`, typed `Endpoint` classes, FastAPI / Django integrations, parsers and responses, htmx response patterns, and **safe URL generation (host header poisoning mitigations)**.
+
+Install one:
+
+```bash
+npx skills add https://github.com/getludic/ludic --skill ludic-components
+npx skills add https://github.com/getludic/ludic --skill ludic-web
+```
+
+Install both at once:
+
+```bash
+npx skills add https://github.com/getludic/ludic --skill ludic-components --skill ludic-web
+# or, equivalently:
+npx skills add https://github.com/getludic/ludic --skill '*'
+```
+
+Once installed, the agent will pick the relevant skill up automatically whenever you ask it to write or modify Ludic code.
+
 ## Contributing
 
 Any contributions to the framework are warmly welcome! Your help will make it a better resource for the community. If you're ready to contribute, read the [contribution guide](https://github.com/getludic/ludic/tree/master/CONTRIBUTING.md).

--- a/skills/ludic-components/SKILL.md
+++ b/skills/ludic-components/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: ludic-components
-description: Build typed, React-like HTML components in Python with Ludic — uses PEP 750 t-strings (Python 3.14+) and pairs with htmx. Use this skill whenever the user is writing or modifying Ludic component code: subclassing Component or ComponentStrict, declaring Attrs TypedDicts, composing HTML elements from ludic.html (div, a, html, head, body, table, form, ...), mixing markup with interpolation via t"...", reaching for catalog widgets (Table, PageLayout, Form, Button, Navigation), wiring htmx attributes (hx_get, hx_post, hx_target, hx_swap) on elements, defining Themes or CSS styles on components, or anything involving the trusted-vs-untrusted (Safe) content boundary. Also trigger on questions about why mypy is flagging a component's children/attrs. Prefer this skill even when the user does not explicitly say "Ludic" — the import `from ludic ...` or any usage of t-strings to build HTML is a strong signal. For building endpoints, request handling, FastAPI/Django integration, or URL generation, use the companion `ludic-web` skill instead.
+description: >-
+  Build typed, React-like HTML components in Python with Ludic — uses PEP 750
+  t-strings (Python 3.14+) and pairs with htmx. Use this skill whenever the
+  user is writing or modifying Ludic component code: subclassing Component or
+  ComponentStrict, declaring Attrs TypedDicts, composing HTML elements from
+  ludic.html (div, a, html, head, body, table, form, ...), mixing markup with
+  interpolation via t"...", reaching for catalog widgets (Table, PageLayout,
+  Form, Button, Navigation), wiring htmx attributes (hx_get, hx_post,
+  hx_target, hx_swap) on elements, defining Themes or CSS styles on
+  components, or anything involving the trusted-vs-untrusted (Safe) content
+  boundary. Also trigger on questions about why mypy is flagging a
+  component's children/attrs. Prefer this skill even when the user does not
+  explicitly say "Ludic" — the import `from ludic ...` or any usage of
+  t-strings to build HTML is a strong signal. For building endpoints,
+  request handling, FastAPI/Django integration, or URL generation, use the
+  companion `ludic-web` skill instead.
 metadata:
   type: framework-guide
   framework: ludic

--- a/skills/ludic-components/SKILL.md
+++ b/skills/ludic-components/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: ludic-components
+description: Build typed, React-like HTML components in Python with Ludic — uses PEP 750 t-strings (Python 3.14+) and pairs with htmx. Use this skill whenever the user is writing or modifying Ludic component code: subclassing Component or ComponentStrict, declaring Attrs TypedDicts, composing HTML elements from ludic.html (div, a, html, head, body, table, form, ...), mixing markup with interpolation via t"...", reaching for catalog widgets (Table, PageLayout, Form, Button, Navigation), wiring htmx attributes (hx_get, hx_post, hx_target, hx_swap) on elements, defining Themes or CSS styles on components, or anything involving the trusted-vs-untrusted (Safe) content boundary. Also trigger on questions about why mypy is flagging a component's children/attrs. Prefer this skill even when the user does not explicitly say "Ludic" — the import `from ludic ...` or any usage of t-strings to build HTML is a strong signal. For building endpoints, request handling, FastAPI/Django integration, or URL generation, use the companion `ludic-web` skill instead.
+metadata:
+  type: framework-guide
+  framework: ludic
+  version: "1.x"
+---
+
+# Ludic Components
+
+Ludic is a Python framework for building HTML pages with a typed, React-like component model that pairs with htmx. v1.x targets **Python 3.14+** and uses **PEP 750 t-strings** (template strings) for templating.
+
+This skill helps you write idiomatic Ludic components: well-composed, type-safe under mypy (with the Ludic mypy plugin), safe by default, and legible. For wiring components into a web app (endpoints, request handling, URL generation, framework integrations), use the companion `ludic-web` skill.
+
+## Mental model
+
+Three layers, top to bottom:
+
+1. **HTML elements** in `ludic.html` (`div`, `a`, `html`, `head`, `body`, `table`, `form`, ...). Each element has a typed signature describing its allowed children and attributes (e.g. `br()` accepts no children; `html(...)` requires `head` as the first child, `body` as the second).
+2. **Components** in `ludic.components` — `Component[TChildren, TAttrs]` and the variadic `ComponentStrict[*TChildrenArgs, TAttrs]`. You subclass these and implement `render()`, which returns an element tree. Components are the unit of reuse and can carry CSS via class-level `classes` and `styles` declarations and read the current `Theme` via `self.theme`.
+3. **Catalog** in `ludic.catalog` — opinionated widgets built on top of the core: layouts (`PageLayout`, `Stack`, `Cluster`, `Sidebar`), forms (`Form`, `FormField`), tables (`Table`, `TableHead`, `TableRow`), navigation, typography, buttons, messages, etc. Reach for these before composing layouts out of raw `div`s — they encode sensible defaults.
+
+The rendering pipeline runs once when you call `.to_html()`: it walks children, expands any t-string `Template` instances, escapes untrusted text, formats attributes (aliases like `class_` → `class`, dict-style `style={...}`, list-style `classes=[...]`), and emits a single HTML string.
+
+## The two things that surprise people
+
+### 1. Use t-strings, not f-strings
+
+In v1.x, code that mixes HTML elements with interpolated text uses **t-strings** (PEP 750), not f-strings:
+
+```python
+# correct — v1.x
+div(t"Hello {b('World')}!")
+
+# wrong — f-strings eagerly stringify b(...), losing escaping and child-tracking
+div(f"Hello {b('World')}!")
+```
+
+The `t"..."` literal produces a `Template` object that Ludic's element constructor detects and expands. If you see `f"... {some_element} ..."` mixing HTML elements with text, change it to `t"..."`.
+
+### 2. The trusted/untrusted content boundary
+
+Everything is HTML-escaped by default. To opt out — for content you've already verified is safe HTML — wrap it in `Safe`:
+
+```python
+from ludic.types import Safe
+
+div("Hello <b>World</b>").to_html()
+# → '<div>Hello &lt;b&gt;World&lt;/b&gt;</div>'   (escaped — safe default)
+
+div(Safe("Hello <b>World</b>")).to_html()
+# → '<div>Hello <b>World</b></div>'              (raw — you take responsibility)
+```
+
+Only use `Safe` for content you control or have sanitized. **Never wrap user input in `Safe`** — that's the XSS hole this whole system exists to prevent. There's also `JavaScript(Safe)` for inline JS bodies.
+
+## Writing a component
+
+Two component classes:
+
+- `Component[TChildren, TAttrs]` — accepts a variable number of children all of one type, plus a single `TAttrs` TypedDict for attributes.
+- `ComponentStrict[*TChildrenArgs, TAttrs]` — uses a `TypeVarTuple` to enforce an exact positional sequence of child types (e.g. "exactly one `TableHead` followed by zero-or-more `TableRow`").
+
+Use `ComponentStrict` when the shape of children matters structurally; use `Component` when children are a homogeneous list.
+
+```python
+from typing import override
+from ludic import Attrs, Component
+from ludic.html import a
+
+class LinkAttrs(Attrs):
+    to: str
+
+class Link(Component[str, LinkAttrs]):
+    classes = ["link"]                      # CSS classes added to the rendered root
+    styles = {"a.link": {"color": "blue"}}  # collected by the style system
+
+    @override
+    def render(self) -> a:
+        return a(
+            *self.children,
+            href=self.attrs["to"],
+            style={"color": self.theme.colors.primary},
+        )
+```
+
+A few rules the Ludic mypy plugin enforces — make sure your app's `pyproject.toml` (or `mypy.ini`) has `plugins = ["ludic.mypy_plugin"]`, otherwise you'll get false positives on every component:
+
+- The generic parameters on `Component[...]` / `ComponentStrict[...]` synthesize `__init__`, so call sites get checked against `TChildren` and `TAttrs`.
+- `Attrs` (and the per-element TypedDicts in `ludic.attrs`) describe **allowed** attributes. Unknown attributes are a type error.
+- For HTML attribute names that collide with Python keywords or contain dashes, use the Python-side alias: `class_` → `class`, `for_` → `for`, `hx_get` → `hx-get`, etc. The `style=` attribute accepts a dict; `classes=` accepts a list.
+
+## htmx attributes on elements
+
+htmx attributes are exposed as `hx_*` keyword arguments on every element with `GlobalAttrs`:
+
+```python
+button(
+    "Load more",
+    hx_get="/items?page=2",
+    hx_target="#items",
+    hx_swap="beforeend",
+)
+```
+
+When you serve the rendered HTML from an endpoint, htmx swaps it into the page. The endpoint side is covered in the `ludic-web` skill — including how to generate the URLs you pass to `hx_get` / `hx_post` safely.
+
+## Catalog: prefer it to raw HTML
+
+Before composing a layout out of `div`s, check `ludic.catalog`:
+
+- `catalog.layouts` — `PageLayout`, `Stack`, `Cluster`, `Sidebar`, `Box`, `Center`, `Cover`, `Grid`, `Switcher`, `Frame`, `Reel`, `Imposter` (adapted from *Every Layout*).
+- `catalog.forms` — `Form`, `FormField`, `InputField`, `TextAreaField`, `SelectField`, `CheckboxField`.
+- `catalog.tables` — `Table`, `TableHead`, `TableRow`.
+- `catalog.navigation`, `catalog.buttons`, `catalog.typography`, `catalog.messages`, `catalog.loaders`, `catalog.headers`, `catalog.items`, `catalog.lists`, `catalog.quotes`, `catalog.icons`, `catalog.pages`.
+
+These are also the best place to learn idiomatic Ludic — they exercise the full surface area of the framework.
+
+## Theming and styles
+
+`Component` subclasses can declare:
+
+- `classes: list[str]` — appended to the root element's class list at render time.
+- `styles: GlobalStyles` — collected at startup so you can emit a single `<style>` block for the page.
+
+Read the active theme via `self.theme` (returns the default theme if none is in scope). Themes flow down the tree automatically, so children see the same theme as the parent rendering them.
+
+## A complete worked example
+
+```python
+from typing import override
+from ludic import Attrs, Component
+from ludic.catalog.layouts import Stack
+from ludic.catalog.typography import Paragraph
+from ludic.html import b, h2
+
+class GreetingAttrs(Attrs):
+    name: str
+
+class Greeting(Component[str, GreetingAttrs]):
+    classes = ["greeting"]
+
+    @override
+    def render(self) -> Stack:
+        return Stack(
+            h2(t"Hello, {b(self.attrs['name'])}!"),
+            Paragraph(*self.children),
+        )
+
+# Usage
+Greeting("Welcome to Ludic.", name="Ada").to_html()
+```
+
+What to notice:
+
+- `Component[str, GreetingAttrs]` says: children are strings, attrs match `GreetingAttrs`.
+- The t-string in `h2(t"Hello, {b(...)}!")` keeps `b(...)` as a real element — it isn't stringified.
+- `self.attrs['name']` flows into `b(...)` and is HTML-escaped on output (because it isn't wrapped in `Safe`).
+- `Stack` from the catalog handles vertical spacing — no need to roll a `div` with margin classes.
+
+## When in doubt
+
+- The [Ludic docs](https://getludic.dev/docs/) cover the public API end-to-end.
+- The [catalog source on GitHub](https://github.com/getludic/ludic/tree/main/ludic/catalog) is the fastest read for idiomatic component patterns.
+- The [examples folder](https://github.com/getludic/ludic/tree/main/examples) shows real components used in htmx patterns (click-to-edit, infinite scroll, lazy loading, file upload, ...).

--- a/skills/ludic-web/SKILL.md
+++ b/skills/ludic-web/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: ludic-web
-description: Build web apps with Ludic's web integration — Starlette-based LudicApp, typed Endpoint classes, and the FastAPI / Django integrations. Use this skill whenever the user is wiring Ludic components into HTTP handlers: routing requests with LudicApp, declaring async endpoints that return components, subclassing ludic.web.endpoints.Endpoint, parsing form data or query params, returning htmx partials, handling redirects, mounting Ludic inside an existing FastAPI or Django app, or generating URLs from a request (request.url_for / request.url_path_for). Always trigger this skill on any code that generates absolute URLs from request data — there is a host header poisoning class of vulnerability that affects every Ludic web app and needs explicit guarding. Also trigger on questions about LudicRequest, LudicResponse, the Starlette/FastAPI/Django bridge, or htmx response patterns (HX-Trigger, HX-Redirect, HX-Push-Url headers). For pure component authoring without an HTTP layer, use the companion `ludic-components` skill.
+description: >-
+  Build web apps with Ludic's web integration — Starlette-based LudicApp,
+  typed Endpoint classes, and the FastAPI / Django integrations. Use this
+  skill whenever the user is wiring Ludic components into HTTP handlers:
+  routing requests with LudicApp, declaring async endpoints that return
+  components, subclassing ludic.web.endpoints.Endpoint, parsing form data
+  or query params, returning htmx partials, handling redirects, mounting
+  Ludic inside an existing FastAPI or Django app, or generating URLs from
+  a request (request.url_for / request.url_path_for). Always trigger this
+  skill on any code that generates absolute URLs from request data — there
+  is a host header poisoning class of vulnerability that affects every
+  Ludic web app and needs explicit guarding. Also trigger on questions
+  about LudicRequest, LudicResponse, the Starlette/FastAPI/Django bridge,
+  or htmx response patterns (HX-Trigger, HX-Redirect, HX-Push-Url
+  headers). For pure component authoring without an HTTP layer, use the
+  companion `ludic-components` skill.
 metadata:
   type: framework-guide
   framework: ludic

--- a/skills/ludic-web/SKILL.md
+++ b/skills/ludic-web/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: ludic-web
+description: Build web apps with Ludic's web integration — Starlette-based LudicApp, typed Endpoint classes, and the FastAPI / Django integrations. Use this skill whenever the user is wiring Ludic components into HTTP handlers: routing requests with LudicApp, declaring async endpoints that return components, subclassing ludic.web.endpoints.Endpoint, parsing form data or query params, returning htmx partials, handling redirects, mounting Ludic inside an existing FastAPI or Django app, or generating URLs from a request (request.url_for / request.url_path_for). Always trigger this skill on any code that generates absolute URLs from request data — there is a host header poisoning class of vulnerability that affects every Ludic web app and needs explicit guarding. Also trigger on questions about LudicRequest, LudicResponse, the Starlette/FastAPI/Django bridge, or htmx response patterns (HX-Trigger, HX-Redirect, HX-Push-Url headers). For pure component authoring without an HTTP layer, use the companion `ludic-components` skill.
+metadata:
+  type: framework-guide
+  framework: ludic
+  version: "1.x"
+---
+
+# Ludic Web
+
+This skill covers the **web integration** side of Ludic — how to serve components over HTTP. The component authoring side (writing `Component` subclasses, t-strings, the catalog, the `Safe` boundary) is covered in the companion `ludic-components` skill.
+
+Ludic's web layer is a thin wrapper around [Starlette](https://www.starlette.io/). The same patterns work in FastAPI and Django via the optional integrations in `ludic.contrib`.
+
+## The basic shape
+
+```python
+from ludic.web import LudicApp
+from ludic.html import b, p
+
+app = LudicApp()
+
+@app.get("/")
+async def homepage() -> p:
+    return p(t"Hello {b('Stranger')}!")
+```
+
+What's happening:
+
+- `LudicApp` is a Starlette `Starlette` subclass that knows how to serialize a returned `BaseElement` into an HTML response (correct content-type, full document if it's a `<html>` root, otherwise a fragment suitable for htmx).
+- The return type annotation (`-> p`) is real — the mypy plugin checks it against the component you actually return.
+- Async is the default. Sync handlers are accepted too.
+
+Run it with any ASGI server:
+
+```bash
+uvicorn web:app
+```
+
+## Endpoints as classes
+
+For anything beyond trivial GETs, prefer the `Endpoint` class — it groups verbs for a single resource and gets the same type-checking treatment as components:
+
+```python
+from ludic.web import LudicApp
+from ludic.web.endpoints import Endpoint
+from ludic.web.parsers import Parser
+
+app = LudicApp()
+
+@app.endpoint("/items/{id:int}")
+class Item(Endpoint[ItemAttrs]):
+    async def get(self) -> ItemView: ...
+    async def put(self, data: Parser[ItemAttrs]) -> ItemView: ...
+    async def delete(self) -> None: ...
+```
+
+`Parser[SomeAttrs]` validates an incoming form/JSON body against the same TypedDict you'd use for component attrs — one schema, two uses.
+
+## htmx response patterns
+
+When an endpoint is called by htmx, return the swap target as a Ludic element — htmx will replace the target on the page:
+
+```python
+@app.post("/items")
+async def create_item(request: Request, data: Parser[ItemAttrs]) -> ItemRow:
+    item = await db.insert(data.attrs)
+    return ItemRow(item)  # htmx swaps this into hx-target
+```
+
+For htmx control headers (`HX-Trigger`, `HX-Redirect`, `HX-Push-Url`, ...), set them on the response:
+
+```python
+from ludic.web.responses import LudicResponse
+
+resp = LudicResponse(MyComponent(...))
+resp.headers["HX-Push-Url"] = "/items/123"
+return resp
+```
+
+## Generating URLs — beware host header poisoning
+
+`Request.url_for(...)` returns an absolute URL whose scheme and host are derived from the incoming request — ultimately from the HTTP `Host` header (and `X-Forwarded-*` headers when proxy headers are trusted). If your app accepts requests with an untrusted `Host`, an attacker can poison every absolute URL you render — including `hx-get` / `hx-post` attributes, links, redirects, and links sent in outbound messages — pointing the browser at an attacker-controlled domain.
+
+**Mitigations:**
+
+- **Prefer `request.url_path_for(...)`** — or `request.url_for(...).path` — for in-app links and htmx attributes. Relative paths cannot be poisoned and are usually what you want anyway.
+- **Install `starlette.middleware.trustedhost.TrustedHostMiddleware`** with an explicit `allowed_hosts` list so the app rejects requests with a forged `Host` header before any handler runs.
+- **Behind a reverse proxy or CDN**, configure `ProxyHeadersMiddleware` (or an equivalent) with a trusted-proxy allowlist so `X-Forwarded-Host` / `X-Forwarded-Proto` are only honored from your own infrastructure.
+
+FastAPI users get the same exposure: the FastAPI integration wraps the incoming request as `LudicRequest`, so `Request.url_for(...)` is reachable from FastAPI handlers and the same advice applies.
+
+```python
+# good — relative path, can't be poisoned
+a("Profile", href=request.url_path_for("profile", user_id=user.id))
+
+button(
+    "Refresh",
+    hx_get=request.url_path_for("items_partial"),
+    hx_target="#items",
+)
+
+# avoid for in-app links — host comes from the request
+a("Profile", href=str(request.url_for("profile", user_id=user.id)))
+```
+
+If you genuinely need an absolute URL (outbound email links, OAuth redirect URIs, sitemap entries, OpenGraph tags), **don't derive it from the request at all** — read it from configuration you control. A `BASE_URL` env var that's validated at startup is fine; a header from a stranger is not.
+
+### A minimal hardened setup
+
+```python
+from starlette.middleware import Middleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from ludic.web import LudicApp
+
+middleware = [
+    # Behind a known proxy/CDN only — set trusted_hosts to your proxy's IP range
+    Middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1"]),
+    # Reject any request whose Host header isn't one of yours
+    Middleware(TrustedHostMiddleware, allowed_hosts=["example.com", "*.example.com"]),
+]
+
+app = LudicApp(middleware=middleware)
+```
+
+Order matters: `ProxyHeadersMiddleware` runs first so it rewrites the client and host info from `X-Forwarded-*`, then `TrustedHostMiddleware` checks the (now-trusted) `Host` against your allowlist.
+
+## Parsers, requests, responses
+
+`ludic.web` re-exports / wraps the Starlette pieces you actually need:
+
+- `LudicRequest` — Starlette `Request` with a couple of Ludic conveniences.
+- `LudicResponse` — used for explicit response construction (custom headers, status codes).
+- `parsers.Parser[TAttrs]` — validates form / JSON / query bodies against a TypedDict and exposes them as `.attrs`.
+- `datastructures.FormData`, `QueryParams` — same shapes Starlette uses.
+- `routing.Route`, `Mount` — for declaring routes outside the `@app.get(...)` decorators.
+
+## FastAPI integration
+
+```python
+from fastapi import FastAPI
+from ludic.contrib.fastapi import LudicRoute
+
+app = FastAPI()
+app.router.route_class = LudicRoute  # makes returns of Ludic elements render as HTML
+
+@app.get("/", response_class=LudicResponse)
+async def home() -> p:
+    return p("Hello from FastAPI + Ludic")
+```
+
+The `[fastapi]` extra installs the dependency: `pip install "ludic[fastapi]"`. The host-header poisoning advice above applies identically here.
+
+## Django integration
+
+```python
+# urls.py
+from ludic.contrib.django import LudicView
+from .views import HomeView
+
+urlpatterns = [path("", LudicView.as_view(component=HomeView))]
+```
+
+The `[django]` extra: `pip install "ludic[django]"`. The Django integration goes through Django's URL resolver and request/response cycle, not Starlette's — so the relevant host-header guard is Django's `ALLOWED_HOSTS` setting and (when proxied) `USE_X_FORWARDED_HOST` / `SECURE_PROXY_SSL_HEADER`. Same threat, framework-native mitigation.
+
+## Endpoint testing
+
+```python
+from starlette.testclient import TestClient
+
+def test_homepage():
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "Hello" in r.text
+```
+
+Because the response body is rendered HTML, you can assert against substrings directly or parse it with whatever HTML library you prefer.
+
+## When in doubt
+
+- The [Ludic web framework docs](https://getludic.dev/docs/web-framework) cover routing, parsers, and responses end-to-end.
+- The [examples folder](https://github.com/getludic/ludic/tree/main/examples) has runnable end-to-end htmx apps — click-to-edit, infinite scroll, lazy loading, file upload, FastAPI integration.
+- Starlette's docs apply to everything `LudicApp` doesn't override — middleware, lifespan, exception handlers all behave normally.


### PR DESCRIPTION
## Summary

- Adds two agent skills under `skills/` — `ludic-components` (component authoring: t-strings, `Component`/`ComponentStrict`, catalog, `Safe` boundary) and `ludic-web` (web layer: `LudicApp`, `Endpoint`, FastAPI/Django integrations, and a host-header-poisoning guard for `request.url_for`).
- Adds an **Agent Skills** section to the README documenting installation via `npx skills add ...`.
- Skills are discoverable by the [`skills`](https://www.npmjs.com/package/skills) CLI (works with Claude Code, Cursor, Codex, Copilot, etc.).

## Test plan

- [x] `npx skills add file://<local-clone> --list` discovers both skills with correct names and descriptions
- [ ] After merge, `npx skills add https://github.com/getludic/ludic --skill ludic-components --skill ludic-web` installs both skills into the active agent's skill directory